### PR TITLE
USB Monitoring

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,6 @@
+
+Some core notes on the development of uratool.
+
+- [Mass Storage Device Enumeration](https://stackoverflow.com/questions/20562263/enumerate-usb-flash-drives-programatically-using-libudev-in-linux)
+    
+    Searching for block devices...

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 
 uratool: ./source/main.c
-	g++ -I./source -ludev -o ./uratool ./source/main.c
+	g++ -I./source -ludev -lblkid -o ./uratool ./source/main.c
 
 clean:
 	rm uratool

--- a/source/core/helpers.h
+++ b/source/core/helpers.h
@@ -4,4 +4,6 @@
 #define FAST_EXIT_ON_ERROR(boolstmt, msg, rtcode) do { if (!boolstmt) \
 	{ if (msg != NULL) printf(msg); exit(rtcode); } } while (0)
 
+#define URATOOL_UDEV_UNREF(pointer, func) do { func(pointer); pointer = NULL; } while (0)
+
 #endif

--- a/source/main.c
+++ b/source/main.c
@@ -3,18 +3,121 @@
 #include <core/helpers.h>
 #include <core/primitives.h>
 
+#if 1
 #include <libudev.h>
 
-int
-main(/*int argc, char** argv*/)
+// -----------------------------------------------------------------------------
+// udev_instance
+// -----------------------------------------------------------------------------
+// Contains information regarding a udev, and used for maintaining lifetimes of
+// the udev constructs (reference counting, and what not).
+
+typedef struct
+{
+	udev* context;
+} uratool_udev_instance;
+
+// -----------------------------------------------------------------------------
+// udev_create & udev_close
+// -----------------------------------------------------------------------------
+// Helper functions which construct and deconstruct the udev lifetimes.
+
+uratool_udev_instance
+uratool_create_udev_instance()
 {
 
-	// Initiate libudev.
-	udev* udev_context = udev_new();
+	uratool_udev_instance instance = {};
+	instance.context = udev_new();
 
-	// Get the enumerables.
-	udev_enumerate* enumerables = udev_enumerate_new(udev_context);
 
-	return 0;
+	return instance;
 }
 
+void
+uratool_close_udev_instance(uratool_udev_instance* instance)
+{
+
+	URATOOL_UDEV_UNREF(instance->context, udev_unref);
+
+}
+
+// -----------------------------------------------------------------------------
+// Entry Point
+// -----------------------------------------------------------------------------
+
+int main(int argc, char *argv[]) {
+#if 0
+    udev *uDev = udev_new();
+    udev_enumerate *enumerate;
+    udev_list_entry *devices, *deviceEntry;
+    udev_device *blockDevice;
+    const char *path;
+
+    enumerate = udev_enumerate_new(uDev);
+    udev_enumerate_add_match_subsystem(enumerate, "block");
+    udev_enumerate_scan_devices(enumerate);
+    devices = udev_enumerate_get_list_entry(enumerate);
+
+    udev_list_entry_foreach(deviceEntry, devices) {
+        path = udev_list_entry_get_name(deviceEntry);
+
+        if (path) {
+            blockDevice = udev_device_new_from_syspath(uDev, path);
+            printf("BLOCK DEVICE: %s\n", udev_device_get_sysname(blockDevice));
+            printf("    PARTUUID: %s\n", udev_device_get_property_value(blockDevice, "ID_PART_ENTRY_UUID"));
+            printf("     DEVNAME: %s\n\n", udev_device_get_property_value(blockDevice, "DEVNAME"));
+            udev_device_unref(blockDevice);
+        }
+
+    }
+
+    udev_enumerate_unref(enumerate);
+    udev_unref(uDev);
+#endif
+
+	uratool_udev_instance instance = uratool_create_udev_instance();	
+
+	// -------------------------------------------------------------------------
+	
+	udev_enumerate* enum_inst = udev_enumerate_new(instance.context);
+	
+	udev_enumerate_add_match_subsystem(enum_inst, "block");
+	udev_enumerate_add_match_property(enum_inst, "DEVTYPE", "partition");
+	
+	udev_enumerate_scan_devices(enum_inst);
+	udev_list_entry* devices = udev_enumerate_get_list_entry(enum_inst);
+	
+	udev_list_entry* device_entry;
+	udev_list_entry_foreach(device_entry, devices)
+	{
+		const char* path = udev_list_entry_get_name(device_entry);
+	
+		if (path)
+		{
+			udev_device* block_device = udev_device_new_from_syspath(instance.context, path);
+			udev_device* usb_device = udev_device_get_parent_with_subsystem_devtype(block_device, "usb", "usb_device");
+			
+			if (block_device && usb_device)
+			{
+				printf("---------------------------\n");
+				printf("DEVICE: %s\n", udev_device_get_sysname(block_device));
+				printf("DEVNAME: %s\n", udev_device_get_property_value(block_device, "DEVNAME"));
+				printf("PARTUUID: %s\n", udev_device_get_property_value(block_device, "ID_PART_ENTRY_UUID"));
+				printf("DEVTYPE: %s\n", udev_device_get_property_value(block_device, "DEVTYPE"));
+				printf("VENDOR: %s\n", udev_device_get_sysattr_value(usb_device, "idVendor"));
+				printf("\n");
+			}
+
+			URATOOL_UDEV_UNREF(block_device, udev_device_unref);
+		}
+
+	}
+
+
+	URATOOL_UDEV_UNREF(enum_inst, udev_enumerate_unref);
+
+	// -------------------------------------------------------------------------
+	
+	uratool_close_udev_instance(&instance);
+}
+#endif

--- a/source/main.c
+++ b/source/main.c
@@ -3,7 +3,6 @@
 #include <core/helpers.h>
 #include <core/primitives.h>
 
-#if 1
 #include <libudev.h>
 
 // -----------------------------------------------------------------------------
@@ -41,45 +40,11 @@ uratool_close_udev_instance(uratool_udev_instance* instance)
 
 }
 
-// -----------------------------------------------------------------------------
-// Entry Point
-// -----------------------------------------------------------------------------
+void
+uratool_enumerate_devices(uratool_udev_instance* instance)
+{
 
-int main(int argc, char *argv[]) {
-#if 0
-    udev *uDev = udev_new();
-    udev_enumerate *enumerate;
-    udev_list_entry *devices, *deviceEntry;
-    udev_device *blockDevice;
-    const char *path;
-
-    enumerate = udev_enumerate_new(uDev);
-    udev_enumerate_add_match_subsystem(enumerate, "block");
-    udev_enumerate_scan_devices(enumerate);
-    devices = udev_enumerate_get_list_entry(enumerate);
-
-    udev_list_entry_foreach(deviceEntry, devices) {
-        path = udev_list_entry_get_name(deviceEntry);
-
-        if (path) {
-            blockDevice = udev_device_new_from_syspath(uDev, path);
-            printf("BLOCK DEVICE: %s\n", udev_device_get_sysname(blockDevice));
-            printf("    PARTUUID: %s\n", udev_device_get_property_value(blockDevice, "ID_PART_ENTRY_UUID"));
-            printf("     DEVNAME: %s\n\n", udev_device_get_property_value(blockDevice, "DEVNAME"));
-            udev_device_unref(blockDevice);
-        }
-
-    }
-
-    udev_enumerate_unref(enumerate);
-    udev_unref(uDev);
-#endif
-
-	uratool_udev_instance instance = uratool_create_udev_instance();	
-
-	// -------------------------------------------------------------------------
-	
-	udev_enumerate* enum_inst = udev_enumerate_new(instance.context);
+	udev_enumerate* enum_inst = udev_enumerate_new(instance->context);
 	
 	udev_enumerate_add_match_subsystem(enum_inst, "block");
 	udev_enumerate_add_match_property(enum_inst, "DEVTYPE", "partition");
@@ -94,7 +59,7 @@ int main(int argc, char *argv[]) {
 	
 		if (path)
 		{
-			udev_device* block_device = udev_device_new_from_syspath(instance.context, path);
+			udev_device* block_device = udev_device_new_from_syspath(instance->context, path);
 			udev_device* usb_device = udev_device_get_parent_with_subsystem_devtype(block_device, "usb", "usb_device");
 			
 			if (block_device && usb_device)
@@ -116,8 +81,23 @@ int main(int argc, char *argv[]) {
 
 	URATOOL_UDEV_UNREF(enum_inst, udev_enumerate_unref);
 
-	// -------------------------------------------------------------------------
-	
+}
+
+// -----------------------------------------------------------------------------
+// Entry Point
+// -----------------------------------------------------------------------------
+
+int main(int argc, char *argv[]) {
+
+
+	// Create a udev instance that we can use to enumerate devices.
+	uratool_udev_instance instance = uratool_create_udev_instance();	
+	uratool_enumerate_devices(&instance);
+
+	// Close the enumeration.
 	uratool_close_udev_instance(&instance);
 }
-#endif
+
+
+
+


### PR DESCRIPTION
Implemented USB monitoring to the project. Uses a busy loop to handle the polling. This should eventually be abstracted to its own thread such that the primary thread can handle user interaction. For now, it shows partitioned devices and their device names (paths) that are available for mounting. We will need to retrieve UUID or some variant of unique identification in order maintain state of registered USB devices.